### PR TITLE
Use translucent titlebars in all modals by default on macOS

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # Note that Maven- and signing-related properties are in <maven-home>/gradle.properties
 javaReleaseVersion=25
-version=6.1.1-SNAPSHOT
+version=6.1.1
 #export JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk-25.0.1+8/Contents/Home
 
 # Ugh, see https://github.com/gradle/gradle/issues/11308

--- a/src/main/java/org/fife/help/HelpDialog.java
+++ b/src/main/java/org/fife/help/HelpDialog.java
@@ -43,6 +43,7 @@ import javax.swing.text.Position;
 import javax.swing.text.html.HTMLDocument;
 import javax.xml.parsers.*;
 
+import org.fife.util.MacOSUtil;
 import org.w3c.dom.*;
 import org.xml.sax.InputSource;
 import org.fife.ui.CleanSplitPaneUI;
@@ -391,6 +392,7 @@ public class HelpDialog extends JFrame implements ActionListener {
 		setTitle(msg.getString("Title"));
 		setIconImage(owner.getIconImage());
 		applyComponentOrientation(orientation);
+		MacOSUtil.setTransparentTitleBar(this, true);
 		pack();
 
 	}

--- a/src/main/java/org/fife/help/TopicsFoundDialog.java
+++ b/src/main/java/org/fife/help/TopicsFoundDialog.java
@@ -24,17 +24,13 @@ import java.util.ResourceBundle;
 
 import javax.swing.JButton;
 import javax.swing.JList;
-import javax.swing.JDialog;
 import javax.swing.JFrame;
 import javax.swing.JPanel;
 import javax.swing.JLabel;
 import javax.swing.BoxLayout;
 import javax.swing.Box;
 
-import org.fife.ui.RListSelectionModel;
-import org.fife.ui.ResizableFrameContentPane;
-import org.fife.ui.RScrollPane;
-import org.fife.ui.UIUtil;
+import org.fife.ui.*;
 
 
 /**
@@ -43,7 +39,7 @@ import org.fife.ui.UIUtil;
  * @author Robert Futrell
  * @version 1.0
  */
-class TopicsFoundDialog extends JDialog {
+class TopicsFoundDialog extends EscapableDialog {
 
 	@Serial
 	private static final long serialVersionUID = 1L;
@@ -124,6 +120,16 @@ class TopicsFoundDialog extends JDialog {
 
 
 	/**
+	 * Overridden to clear any selected index.
+	 */
+	@Override
+	protected void escapePressed() {
+		selectedIndex = -1;
+		super.escapePressed();
+	}
+
+
+	/**
 	 * Returns the index the user selected, or <code>-1</code> if they
 	 * canceled the dialog.
 	 *
@@ -156,15 +162,9 @@ class TopicsFoundDialog extends JDialog {
 
 		@Override
 		public void keyPressed(KeyEvent e) {
-			switch (e.getKeyCode()) {
-				case KeyEvent.VK_ENTER -> {
-					selectedIndex = choicesList.getSelectedIndex();
-					setVisible(false);
-				}
-				case KeyEvent.VK_ESCAPE -> {
-					selectedIndex = -1;
-					setVisible(false);
-				}
+			if (e.getKeyCode() == KeyEvent.VK_ENTER) {
+				selectedIndex = choicesList.getSelectedIndex();
+				setVisible(false);
 			}
 		}
 

--- a/src/main/java/org/fife/ui/EscapableDialog.java
+++ b/src/main/java/org/fife/ui/EscapableDialog.java
@@ -4,6 +4,8 @@
  */
 package org.fife.ui;
 
+import org.fife.util.MacOSUtil;
+
 import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;
@@ -103,6 +105,7 @@ public class EscapableDialog extends JDialog {
 	 */
 	private void init() {
 		setEscapeClosesDialog(true);
+		MacOSUtil.applyMacOsTweaks(this);
 	}
 
 

--- a/src/main/java/org/fife/ui/FontDialog.java
+++ b/src/main/java/org/fife/ui/FontDialog.java
@@ -10,6 +10,8 @@
  */
 package org.fife.ui;
 
+import org.fife.util.MacOSUtil;
+
 import java.awt.*;
 import java.awt.event.*;
 import java.io.Serial;
@@ -246,6 +248,7 @@ public class FontDialog extends JDialog implements ActionListener,
 		setResizable(false);
 		setModal(true);
 		applyComponentOrientation(orientation);
+		MacOSUtil.applyMacOsTweaks(this);
 		pack();
 
 

--- a/src/main/java/org/fife/ui/GetKeyStrokeDialog.java
+++ b/src/main/java/org/fife/ui/GetKeyStrokeDialog.java
@@ -10,6 +10,8 @@
  */
 package org.fife.ui;
 
+import org.fife.util.MacOSUtil;
+
 import java.awt.BorderLayout;
 import java.awt.ComponentOrientation;
 import java.awt.Dialog;
@@ -34,6 +36,7 @@ import javax.swing.SwingUtilities;
  * @author Robert Futrell
  * @version 1.0
  */
+// Note: This isn't an EscapableDialog to allow odd shortcuts like Cmd+Escape.
 public class GetKeyStrokeDialog extends JDialog {
 
 	@Serial
@@ -113,6 +116,7 @@ public class GetKeyStrokeDialog extends JDialog {
 		setModal(true);
 		setDefaultCloseOperation(JDialog.DO_NOTHING_ON_CLOSE);
 		applyComponentOrientation(orientation);
+		MacOSUtil.applyMacOsTweaks(this);
 		pack();
 
 	}

--- a/src/main/java/org/fife/ui/UIUtil.java
+++ b/src/main/java/org/fife/ui/UIUtil.java
@@ -877,6 +877,18 @@ public final class UIUtil {
 
 
 	/**
+	 * Returns {@code true} or the boolean value of a system property.
+	 *
+	 * @param propertyName The property to check.
+	 * @return The result value.
+	 */
+	public static boolean isNullOrTrue(String propertyName) {
+		String value = System.getProperty(propertyName);
+		return value == null || Boolean.parseBoolean(value);
+	}
+
+
+	/**
 	 * This method is ripped off from <code>SpringUtilities.java</code> found
 	 * on Sun's Java Tutorial pages.  It takes a component whose layout is
 	 * <code>SpringLayout</code> and organizes the components it contains into

--- a/src/main/java/org/fife/ui/rtextfilechooser/RTextFileChooserOptionPanel.java
+++ b/src/main/java/org/fife/ui/rtextfilechooser/RTextFileChooserOptionPanel.java
@@ -43,12 +43,9 @@ import javax.swing.event.DocumentListener;
 import javax.swing.table.DefaultTableModel;
 import javax.swing.table.TableCellRenderer;
 
-import org.fife.ui.OptionsDialogPanel;
-import org.fife.ui.RColorSwatchesButton;
-import org.fife.ui.ResizableFrameContentPane;
-import org.fife.ui.LabelValueComboBox;
-import org.fife.ui.UIUtil;
+import org.fife.ui.*;
 import org.fife.ui.modifiabletable.*;
+import org.fife.util.MacOSUtil;
 import org.fife.util.SubstanceUtil;
 
 
@@ -417,7 +414,7 @@ public class RTextFileChooserOptionPanel extends OptionsDialogPanel
 	 * The dialog that allows the user to add or modify an extension/color
 	 * mapping.
 	 */
-	static class ExtensionColorMappingDialog extends JDialog
+	static class ExtensionColorMappingDialog extends EscapableDialog
 			implements ActionListener, ChangeListener, DocumentListener {
 
 		static final int OK		= 0;
@@ -478,6 +475,7 @@ public class RTextFileChooserOptionPanel extends OptionsDialogPanel
 			getRootPane().setDefaultButton(okButton);
 			setModal(true);
 			applyComponentOrientation(orientation);
+			MacOSUtil.applyMacOsTweaks(this);
 			pack();
 
 		}
@@ -528,7 +526,7 @@ public class RTextFileChooserOptionPanel extends OptionsDialogPanel
 		}
 
 		public int showMappingDialog() {
-			rc = CANCEL; // Set here in case they "X" the dialog out.
+			rc = CANCEL; // Set here in case they "X" the dialog out or press Escape.
 			SwingUtilities.invokeLater(() -> {
 				extensionField.requestFocusInWindow();
 				extensionField.selectAll();

--- a/src/main/java/org/fife/util/MacOSUtil.java
+++ b/src/main/java/org/fife/util/MacOSUtil.java
@@ -5,6 +5,7 @@
 package org.fife.util;
 
 import org.fife.ui.OS;
+import org.fife.ui.UIUtil;
 
 import javax.swing.*;
 
@@ -22,6 +23,13 @@ import javax.swing.*;
  * @version 1.0
  */
 public final class MacOSUtil {
+
+	/**
+	 * By default, {@code GUIApplication}s will create modals with transparent title bars on macOS.
+	 * If you don't want that, set this property to {@code false}.
+	 */
+	public static final String PROPERTY_APP_MODALS_HAVE_TRANSPARENT_TITLE_BAR =
+		"org.fife.mac.appModalsHaveTransparentTitleBar";
 
 	/**
 	 * macOS-specific system property that determines the color to use for window title bars (light,
@@ -69,6 +77,18 @@ public final class MacOSUtil {
 	 */
 	private MacOSUtil() {
 		// Do nothing (comment for Sonar)
+	}
+
+
+	/**
+	 * Applies modal-specific macOS tweaks to a dialog, as defined by system properties.
+	 *
+	 * @param dialog The dialog to update.
+	 */
+	public static void applyMacOsTweaks(JDialog dialog) {
+		if (UIUtil.isNullOrTrue(PROPERTY_APP_MODALS_HAVE_TRANSPARENT_TITLE_BAR)) {
+			setTransparentTitleBar(dialog, true);
+		}
 	}
 
 


### PR DESCRIPTION
* Make all modals in this library check a system property and, by default, use translucent title bars for modals if running on macOS. If you don't want this behavior, set the system property `org.fife.mac.appModalsHaveTransparentTitleBar=true`.
* Bump version to 6.1.1